### PR TITLE
Bump connection timeouts to 60 seconds

### DIFF
--- a/openqa_bugfetcher/issues/__init__.py
+++ b/openqa_bugfetcher/issues/__init__.py
@@ -47,7 +47,7 @@ class BugzillaBaseIssue(BaseIssue):
     def fetch(self, conf):
         def json_rpc_get(url, method, params):
             get_params = OrderedDict({"method": method, "params": json.dumps([params])})
-            return requests.get(url, params=get_params, timeout=10)
+            return requests.get(url, params=get_params, timeout=60)
 
         issue_id = self.bugid.split("#")[1]
         req = json_rpc_get(self.url, "Bug.get", {"ids": [issue_id]})

--- a/openqa_bugfetcher/issues/bugzilla_issue.py
+++ b/openqa_bugfetcher/issues/bugzilla_issue.py
@@ -22,7 +22,7 @@ class BugzillaIssue(BaseIssue):
                 cfg = conf["bugzilla"]
                 if cfg.get("api_key"):
                     get_params["api_key"] = cfg["api_key"]
-                return requests.get(url, params=get_params, timeout=10)
+                return requests.get(url, params=get_params, timeout=60)
 
             req = rest_get_bug(issue_id)
             data = req.json()
@@ -46,7 +46,7 @@ class BugzillaIssue(BaseIssue):
         else:
             # Workaround for bugzilla API unavailable from non-employee accounts
             url = f"https://bugzilla.suse.com/show_bug.cgi?id={issue_id}"
-            req = requests.get(url, timeout=10)
+            req = requests.get(url, timeout=60)
             title = req.text.split("<title>", 1)[1].split("</title>", 1)[0]
             assert title != "Access Denied", "Insufficient permission to access this bug"
             if title in ("Invalid Bug ID", "Search by bug number"):

--- a/openqa_bugfetcher/issues/github_issue.py
+++ b/openqa_bugfetcher/issues/github_issue.py
@@ -13,7 +13,7 @@ class GitHubIssue(BaseIssue):
             auth = None
             if "client_id" in conf["github"] and "client_secret" in conf["github"]:
                 auth = (conf["github"]["client_id"], conf["github"]["client_secret"])
-            req = requests.get(url, auth=auth, timeout=10)
+            req = requests.get(url, auth=auth, timeout=60)
             assert req.status_code != 403, "Github ratelimiting"
             if req.ok:
                 data = req.json()

--- a/openqa_bugfetcher/issues/jira_issue.py
+++ b/openqa_bugfetcher/issues/jira_issue.py
@@ -10,7 +10,7 @@ class JiraIssue(BaseIssue):
         issue_id = self.bugid.split("#")[1]
         url = f"https://jira.suse.com/rest/api/2/issue/{issue_id}"
         cred = conf["jira"]
-        req = requests.get(url, auth=(cred["user"], cred["pass"]), timeout=10)
+        req = requests.get(url, auth=(cred["user"], cred["pass"]), timeout=60)
         if req.ok:
             data = req.json()["fields"]
             self.title = data["summary"]

--- a/openqa_bugfetcher/issues/progress_issue.py
+++ b/openqa_bugfetcher/issues/progress_issue.py
@@ -9,7 +9,7 @@ class ProgressIssue(BaseIssue):
     def fetch(self, conf):
         issue_id = self.bugid.split("#")[1]
         url = f"https://progress.opensuse.org/issues/{issue_id}.json"
-        req = requests.get(url, headers={"X-Redmine-API-Key": conf["progress"]["api_key"]}, timeout=10)
+        req = requests.get(url, headers={"X-Redmine-API-Key": conf["progress"]["api_key"]}, timeout=60)
         if req.ok:
             data = req.json()["issue"]
             self.title = data["subject"]


### PR DESCRIPTION
recent connection timeouts show that 10 seconds might be to little. As the script doesn't have strict runtime requirements and big services like e.g. bugzilla can get quite slow I made the reasonable assumption that 60 seconds for a connection is fine. From the commit history I couldn't find a reason why the inital 10 seconds where choosen so I assume this was just a default suggestion of pylint.