### PR TITLE
chore(ci): bump checkout to v6

### DIFF
--- a/.github/workflows/pychecks.yml
+++ b/.github/workflows/pychecks.yml
@@ -13,7 +13,7 @@ jobs:
         python-version: [3.8, 3.9, 3.11]
 
     steps:
-     - uses: actions/checkout@v2
+     - uses: actions/checkout@v6
      - name: Setu up Python ${{ matrix.python-version}}
        uses: actions/setup-python@v2
        with:


### PR DESCRIPTION
This also fixes a warning about outdated nodejs